### PR TITLE
Add searchmetrics_config.yml to avoid credentials push

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 /pkg/
 /spec/reports/
 /tmp/
+
+# project, testing specific
+spec/searchmetrics_config.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
   allow_failures:
     - rvm: ruby-head
   fast_finish: true
+before_script:
+  - cp spec/searchmetrics_config.yml.example spec/searchmetrics_config.yml
 script:
   - bundle exec rake
   - bundle exec rubocop

--- a/README.md
+++ b/README.md
@@ -103,6 +103,17 @@ release a new version, update the version number in `version.rb`, and then run
 git commits and tags, and push the `.gem` file to
 [rubygems.org](https://rubygems.org).
 
+## Testing
+
+First you need to have API key and secret and put them on
+`spec/searchmetrics_config.yml`. You can find an example in
+`spec/searchmetrics_config.yml.example`.
+
+
+```
+bundle exec rspec
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at

--- a/spec/searchmetrics_config.yml.example
+++ b/spec/searchmetrics_config.yml.example
@@ -1,0 +1,3 @@
+:searchmetrics:
+  :api_key: 'xxx'
+  :api_secret: 'xxx'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,5 +2,5 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'searchmetrics_client'
 require 'vcr'
 
-spec_root = File.expand_path('../', __FILE__)
-Dir[File.join(spec_root, 'support/**/*.rb')].each { |f| require f }
+SPEC_ROOT = File.expand_path('../', __FILE__)
+Dir[File.join(SPEC_ROOT, 'support/**/*.rb')].each { |f| require f }

--- a/spec/support/with_api_credentials_context.rb
+++ b/spec/support/with_api_credentials_context.rb
@@ -1,6 +1,10 @@
 RSpec.shared_context 'with api credentials' do
-  let(:api_key) { 'Your api key' }
-  let(:api_secret) { 'Your api secret' }
+  let(:api_config) do
+    YAML.load_file(File.join(SPEC_ROOT, 'searchmetrics_config.yml'))
+  end
+  let(:api_key) { api_config[:searchmetrics][:api_key] }
+  let(:api_secret) { api_config[:searchmetrics][:api_secret] }
+
   before(:each) do
     SearchmetricsClient.configure do |config|
       config.api_key    = api_key


### PR DESCRIPTION
With that we don't need to checkout each commit the file `spec/support/with_api_credentials_context.rb`
