### PR TITLE
Version 0.2.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,0 +1,11 @@
+
+0.2.0 / 2016-02-24
+==================
+
+  * Use API v3 per default
+  * Drop oauth v1 support
+
+0.1.0 / 2015-11-24
+==================
+
+  * Initial version released

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ end
 ```
 
 Additionally you can specify `api_version` and `api_url`, which defaults to
-`v1` and `http://api.searchmetrics.com` regardless.
+`v3` and `http://api.searchmetrics.com` regardless.
 
 ## Usage
 
@@ -85,7 +85,7 @@ response.endpoint # => "ResearchKeywordsGetListKeywordinfo"
 `#url` returns requested url:
 
 ```ruby
-response.url # => "http://api.searchmetrics.com/v1/ResearchKeywordsGetListKeywordinfo.json?countrycode=DE&keyword=ruby"
+response.url # => "http://api.searchmetrics.com/v3/ResearchKeywordsGetListKeywordinfo.json?countrycode=DE&keyword=ruby"
 ```
 
 Access to raw response is available by methods `#header` and `#body`.

--- a/lib/searchmetrics_client/version.rb
+++ b/lib/searchmetrics_client/version.rb
@@ -1,3 +1,3 @@
 module SearchmetricsClient
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.2.0'.freeze
 end


### PR DESCRIPTION
#0.2.0 / 2016-02-24
- Use API v3 per default
- Drop oauth v1 support
#0.1.0 / 2015-11-24
- Initial version released
